### PR TITLE
Set DispatcherPriority to Input

### DIFF
--- a/src/CyberPlayer.Player/Views/MainWindow.axaml.cs
+++ b/src/CyberPlayer.Player/Views/MainWindow.axaml.cs
@@ -287,7 +287,7 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>, IParentPa
         Dispatcher.UIThread.Post(() =>
         {
             ViewModel!.MpvPlayer.LoadFile();
-        });
+        }, DispatcherPriority.Input);
 #endif
     }
 


### PR DESCRIPTION
Depending on the video's encoding, sometimes LoadFile() would be called before the Avalonia OpenGLVideoView would be ready.

Resolves #9