### PR TITLE
AppExiting Observable now uses Closing event

### DIFF
--- a/src/CyberPlayer.Player/ViewModels/ViewModelBase.cs
+++ b/src/CyberPlayer.Player/ViewModels/ViewModelBase.cs
@@ -31,7 +31,7 @@ public class ViewModelBase : ReactiveObject
     static ViewModelBase()
     {
         MainWindow = Locator.Current.GetService<MainWindow>()!;
-        AppExiting = MainWindow.Events().Closed;
+        AppExiting = MainWindow.Events().Closing;
     }
 
     protected static void ExitApp(EventArgs? args = null)


### PR DESCRIPTION
Resolves #7 which was due to Avalonia window resources being released before mpv's. Now the correct order will take place allowing the application to close properly