### PR TITLE
Implement mpv property observables and async commands

### DIFF
--- a/src/CyberPlayer.Player/AppSettings/Settings.cs
+++ b/src/CyberPlayer.Player/AppSettings/Settings.cs
@@ -11,10 +11,6 @@ public class Settings
 {
     public bool UpdaterIncludePreReleases { get; set; } = false;
 
-    public int SeekRefreshRate { get; set; } = 100;
-
-    public int FrameStepUpdateDelay { get; set; } = 100;
-
     public int TimeCodeLength { get; set; } = 8;
 
     public Renderer Renderer { get; set; } = Renderer.Hardware;

--- a/src/CyberPlayer.Player/ViewModels/MainWindowViewModel.cs
+++ b/src/CyberPlayer.Player/ViewModels/MainWindowViewModel.cs
@@ -82,11 +82,10 @@ public class MainWindowViewModel : ViewModelBase
 
         AppExiting.Subscribe(_ =>
         {
-            MpvPlayer.UpdateSliderTaskCts.Cancel();
             MpvPlayer.MpvContext.Dispose();
             Settings.Export(BuildConfig.SettingsPath);
         });
-            
+        
         CheckForUpdatesCommand = ReactiveCommand.CreateFromTask(CheckForUpdates);
         MediaPickerCommand = ReactiveCommand.CreateFromTask(MediaPicker);
         OpenWebLinkCommand = ReactiveCommand.Create<string>(GenStatic.OpenWebLink);

--- a/src/LibMpv.Context/LibMpv.Context.csproj
+++ b/src/LibMpv.Context/LibMpv.Context.csproj
@@ -12,4 +12,8 @@
     <ProjectReference Include="..\LibMpv.Client\LibMpv.Client.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/LibMpv.Context/MpvContext.Async.cs
+++ b/src/LibMpv.Context/MpvContext.Async.cs
@@ -1,0 +1,32 @@
+namespace LibMpv.Context;
+
+public partial class MpvContext
+{
+    private readonly MpvUserDataStorage _mpvCommandUserDataStorage = new();
+    
+    public async Task CommandAsync(params string[] args)
+    {
+        var tcs = new TaskCompletionSource<int>();
+        var userData = _mpvCommandUserDataStorage.GetAvailableUserData();
+        
+        AsyncCommandReply += OnAsyncCommandReply;
+        CommandAsync(userData, args);
+        
+        var code = await tcs.Task;
+        
+        AsyncCommandReply -= OnAsyncCommandReply;
+        _mpvCommandUserDataStorage.FreeUserData(userData);
+        
+        CheckCode(code);
+        
+        return;
+        
+        void OnAsyncCommandReply(object? _, MpvReplyEventArgs e)
+        {
+            if (e.ReplyData == userData)
+            {
+                tcs.SetResult(e.ErrorCode);
+            }
+        }
+    }
+}

--- a/src/LibMpv.Context/MpvPropertyObservable.cs
+++ b/src/LibMpv.Context/MpvPropertyObservable.cs
@@ -1,0 +1,55 @@
+namespace LibMpv.Context;
+
+public class MpvPropertyObservable<T> : IObservable<T>
+{
+    protected readonly List<IObserver<T>> Observers = new();
+    protected readonly MpvContext Mpv;
+    protected readonly ulong MpvUserData;
+    
+    public MpvPropertyObservable(MpvContext mpv, ulong mpvUserData)
+    {
+        Mpv = mpv;
+        MpvUserData = mpvUserData;
+    }
+
+    private class Unsubscriber : IDisposable
+    {
+        private readonly MpvPropertyObservable<T> _observable;
+        private readonly IObserver<T> _observer;
+        
+        public Unsubscriber(MpvPropertyObservable<T> observable, IObserver<T> observer)
+        {
+            _observable = observable;
+            _observer = observer;
+        }
+
+        public void Dispose()
+        {
+            _observable.Observers.Remove(_observer);
+            if (_observable.Observers.Count == 0)
+            {
+                _observable.Mpv.UnobserveProperty(_observable.MpvUserData);
+                var propertyChangedObservables = _observable.Mpv.PropertyChangedObservables;
+                // This could be better by already having the key passed in
+                var observableKey = propertyChangedObservables.Single(x => ReferenceEquals(x.Value, _observable)).Key;
+                propertyChangedObservables.Remove(observableKey);
+            }
+        }
+    }
+    
+    public IDisposable Subscribe(IObserver<T> observer)
+    {
+        if (!Observers.Contains(observer))
+            Observers.Add(observer);
+
+        return new Unsubscriber(this, observer);
+    }
+
+    internal void OnNextAll(T nextVal)
+    {
+        foreach (var observer in Observers)
+        {
+            observer.OnNext(nextVal);
+        }
+    }
+}

--- a/src/LibMpv.Context/MpvUserDataStorage.cs
+++ b/src/LibMpv.Context/MpvUserDataStorage.cs
@@ -1,0 +1,38 @@
+namespace LibMpv.Context;
+
+public class MpvUserDataStorage
+{
+    // True if in use
+    private readonly Dictionary<int, bool> _userData = new();
+    private readonly object _lock = new();
+    
+    // Could be better but we will likely not use many async methods anyway
+    public ulong GetAvailableUserData()
+    {
+        lock (_lock)
+        {
+            var i = 1;
+            while (_userData.TryGetValue(i, out var result))
+            {
+                if (!result)
+                {
+                    _userData[i] = true;
+                    return (ulong)i;
+                }
+
+                i++;
+            }
+            
+            _userData.Add(i, true);
+            return (ulong)i;
+        }
+    }
+
+    public void FreeUserData(ulong userData)
+    {
+        lock (_lock)
+        {
+            _userData[(int)userData] = false;
+        }
+    }
+}


### PR DESCRIPTION
Updating the slider will now use mpv events instead of constantly calling GetPropertyDouble().