### PR TITLE
Change to global mutex

### DIFF
--- a/src/CyberPlayer.Player/BuildConfig.cs
+++ b/src/CyberPlayer.Player/BuildConfig.cs
@@ -51,7 +51,8 @@ public static class BuildConfig
     public const string AssetIdentifierInstance = "multi";
 #elif SINGLE
     public const string AssetIdentifierInstance = "single";
-    public const string Guid = "{8EC49017-B0B5-4EDE-83EE-7E2799BCB935}";
+    public const string Guid = "8EC49017-B0B5-4EDE-83EE-7E2799BCB935";
+    public const string MutexId = "Global\\{8EC49017-B0B5-4EDE-83EE-7E2799BCB935}";
 #endif
 
 #if DEBUG

--- a/src/CyberPlayer.Player/Helpers/Setup.cs
+++ b/src/CyberPlayer.Player/Helpers/Setup.cs
@@ -16,11 +16,11 @@ namespace CyberPlayer.Player.Helpers;
 public static class Setup
 {
 #if SINGLE
-    public static readonly Mutex Mutex = new(true, BuildConfig.Guid);
+    public static readonly Mutex GlobalMutex = new(true, BuildConfig.MutexId);
     
     public static void CheckInstance(string[] args)
     {
-        if (Mutex.WaitOne(TimeSpan.Zero, true))
+        if (GlobalMutex.WaitOne(TimeSpan.Zero, true))
         {
             var server = new NamedPipeServerStream(BuildConfig.Guid);
             var cts = new CancellationTokenSource();

--- a/src/CyberPlayer.Player/Program.cs
+++ b/src/CyberPlayer.Player/Program.cs
@@ -24,7 +24,8 @@ namespace CyberPlayer.Player
                 .StartWithClassicDesktopLifetime(args);
             
 #if SINGLE
-            Setup.Mutex.ReleaseMutex();
+            Setup.GlobalMutex.ReleaseMutex();
+            Setup.GlobalMutex.Dispose();
 #endif
         }
 


### PR DESCRIPTION
Use global prefix for mac/linux. Guid must be used for the named pipe otherwise the mutexid creates a temp path that is a few characters too long.