### PR TITLE
Crash on exiting with opengl

### DIFF
--- a/src/LibMpv.Context/MpvContext.Rendering.cs
+++ b/src/LibMpv.Context/MpvContext.Rendering.cs
@@ -220,6 +220,7 @@ public sealed unsafe partial class MpvContext
 
     public void StopRendering()
     {
+        if (_disposed) return;
         Command("stop");
         if (_renderContext != null)
         {


### PR DESCRIPTION
By calling dispose in the AppExiting subscription in the MainWindowViewModel ctor, StopRendering() will be called from the dispose method first, then from OnOpenGlDeinit() in OpenGlVideoView.