### PR TITLE
Fix log instances being one more than the setting

### DIFF
--- a/src/CyberPlayer.Player/Business/FFmpeg.cs
+++ b/src/CyberPlayer.Player/Business/FFmpeg.cs
@@ -38,6 +38,7 @@ public class FFmpeg : IDisposable
         _log = new LoggerConfiguration()
             .ConfigureDefaults(filePath, settings.LogLevel)
             .CreateLogger();
+        _log.Information("FFmpeg logger initialized");
         _log.CleanupLogFiles(BuildConfig.LogDirectory, "ffmpeg_output*.log", 10);
         
         var ffmpegPath = string.IsNullOrWhiteSpace(settings.FFmpegDir) ?


### PR DESCRIPTION
One log more than what was set in the settings would be preserved. Now we log before cleaning up log files to ensure the new log file already exists.