### PR TITLE
Windows native library path resolve

### DIFF
--- a/src/CyberPlayer.Player/AppSettings/Settings.cs
+++ b/src/CyberPlayer.Player/AppSettings/Settings.cs
@@ -150,7 +150,7 @@ public class Settings
     {
         if (OperatingSystem.IsMacOS()) return GetMacDir(name, type);
         if (OperatingSystem.IsLinux()) return GetLinuxDir(name, type);
-        if (OperatingSystem.IsWindows()) return string.Empty; // TODO Maybe check path environment variable
+        if (OperatingSystem.IsWindows()) return AppDomain.CurrentDomain.BaseDirectory; // TODO Maybe check path environment variable
         throw new PlatformNotSupportedException();
     }
     


### PR DESCRIPTION
Returning an empty string means that the libraries will be searched for in the current working directory only. This is why open with would not work but opening normally would.